### PR TITLE
[ADE-166] Answer only medical questions and use claude 3.7 sonnet

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -15,10 +15,11 @@ if [ -n "$FRONTEND_CHANGES" ]; then
 
   # Navigate to frontend directory
   cd frontend || exit 1
+  
+  # Remove dependency on husky.sh
+  # . "$(dirname -- "$0")/_/husky.sh"
 
-  . "$(dirname -- "$0")/_/husky.sh"
-
-  cd frontend && npm run lint && npm run test:ci
+  npm run lint && npm run test:ci
 
   # Capture the exit code
   TEST_EXIT_CODE=$?
@@ -43,7 +44,9 @@ BACKEND_CHANGES=$(git diff --name-only $RANGE | grep "^backend/" || true)
 if [ -n "$BACKEND_CHANGES" ]; then
     echo "Backend changes detected. Running backend lint..."
 
-    . "$(dirname -- "$0")/_/husky.sh"
+    # Remove dependency on husky.sh
+    # . "$(dirname -- "$0")/_/husky.sh"
+    
     cd backend && npm run lint
 else
   echo "No backend changes detected. Skipping backend tests."

--- a/frontend/src/common/services/ai/bedrock.service.ts
+++ b/frontend/src/common/services/ai/bedrock.service.ts
@@ -8,6 +8,16 @@ const getContentFilteredMessage = (): string => {
   return i18n.t('ai.content_filtered', { ns: 'errors' });
 };
 
+// This function provides a healthcare-focused system prompt
+const getHealthcareSystemPrompt = (): string => {
+  return `You are a healthcare assistant that only responds to medical and healthcare-related questions. 
+If a user asks a question that is not directly related to healthcare, medicine, medical reports, 
+health conditions, treatments, or medical terminology, respond with: 
+"${i18n.t('ai.non_healthcare_topic', { ns: 'errors', defaultValue: "I couldn't find an answer. Please try rephrasing your question or consult your healthcare provider." })}"
+
+Only provide information about healthcare topics, and always mention that users should consult healthcare professionals for personalized medical advice.`;
+};
+
 export interface ChatMessage {
   role: 'user' | 'assistant' | 'system';
   content: string;
@@ -20,21 +30,44 @@ export interface ChatSession {
   updatedAt: Date;
 }
 
-// Interfaces for Bedrock API responses
-interface BedrockResult {
-  tokenCount: number;
-  outputText: string;
-  completionReason: 'CONTENT_FILTERED' | 'COMPLETE' | 'LENGTH' | 'STOP_SEQUENCE' | string;
+// Interfaces for Claude 3.7 Sonnet response
+interface ClaudeContentBlock {
+  type: string;
+  text?: string;
+  reasoningContent?: {
+    reasoningText: string;
+  };
 }
 
-interface BedrockResponse {
-  inputTextTokenCount: number;
-  results: BedrockResult[];
+interface ClaudeResponse {
+  id: string;
+  type: string;
+  role: string;
+  content: ClaudeContentBlock[];
+  model: string;
+  stop_reason: string;
+  stop_sequence: string | null;
+  usage: {
+    input_tokens: number;
+    output_tokens: number;
+  };
+}
+
+// Claude request body interface
+interface ClaudeRequestBody {
+  anthropic_version: string;
+  max_tokens: number;
+  messages: {
+    role: 'user' | 'assistant' | 'system';
+    content: { type: string; text: string; }[];
+  }[];
+  temperature: number;
+  top_p: number;
+  system?: string;
 }
 
 class BedrockService {
   private client: BedrockRuntimeClient | null = null;
-  private readonly MODEL_ID = 'amazon.titan-text-lite-v1';
   private sessions: Map<string, ChatSession> = new Map();
   private isTestEnvironment: boolean;
   private contentFilteredCount: number = 0; // Track number of filtered responses
@@ -86,16 +119,14 @@ class BedrockService {
     }
   }
 
-  private handleBedrockResponse(parsedResponse: BedrockResponse): string {
-    // Check if we have results
-    if (!parsedResponse.results || !parsedResponse.results.length) {
-      throw new Error('Invalid response structure: missing results');
+  private handleClaudeResponse(response: ClaudeResponse): string {
+    // Check if response has content
+    if (!response.content || !response.content.length) {
+      throw new Error('Invalid response structure: missing content');
     }
     
-    const result = parsedResponse.results[0];
-    
     // Check for content filtering
-    if (result.completionReason === "CONTENT_FILTERED") {
+    if (response.stop_reason === "content_filtered") {
       // Increment counter for analytics
       this.contentFilteredCount++;
       
@@ -103,40 +134,59 @@ class BedrockService {
       return getContentFilteredMessage();
     }
 
+    // Extract text from content blocks
+    const textContent = response.content
+      .filter(block => block.type === 'text' && block.text)
+      .map(block => block.text)
+      .join('\n');
     
-    return result.outputText;
+    return textContent || '';
   }
 
-  private async invokeModel(prompt: string): Promise<string> {
+  private async invokeModel(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
     // In test environment, return a mock response
     if (this.isTestEnvironment || !this.client) {
-      return `This is a test response to: "${prompt}"`;
+      return `This is a test response to: "${messages[messages.length - 1]?.content || 'No message'}"`;
     }
     
+    // Format messages for Claude API
+    const formattedMessages = messages.map(msg => ({
+      role: msg.role,
+      content: [{ type: 'text', text: msg.content }]
+    }));
+    
+    // Prepare request body for Claude 3.7 Sonnet
+    const requestBody: ClaudeRequestBody = {
+      anthropic_version: "bedrock-2023-05-31",
+      max_tokens: 4096,
+      messages: formattedMessages,
+      temperature: 0.7,
+      top_p: 0.9
+    };
+    
+    // Add system prompt if provided
+    if (systemPrompt) {
+      requestBody.system = systemPrompt;
+    }
+
+    // Use the cross-region inference profile ID as the model ID (following AWS docs)
+    // Do not specify inferenceProfileArn separately 
     const input = {
-      modelId: this.MODEL_ID,
+      modelId: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
       contentType: 'application/json',
       accept: 'application/json',
-      body: JSON.stringify({
-        inputText: prompt,
-        textGenerationConfig: {
-          maxTokenCount: 4096,
-          stopSequences: [],
-          temperature: 0.7,
-          topP: 1,
-        },
-      }),
+      body: JSON.stringify(requestBody),
     };
 
     try {
       const command = new InvokeModelCommand(input);
       const response = await this.client.send(command);
       const responseBody = new TextDecoder().decode(response.body);
-      const parsedResponse = JSON.parse(responseBody) as BedrockResponse;
+      const parsedResponse = JSON.parse(responseBody) as ClaudeResponse;
       
-      return this.handleBedrockResponse(parsedResponse);
+      return this.handleClaudeResponse(parsedResponse);
     } catch (error) {
-      console.error('Error invoking Bedrock model:', error);
+      console.error('Error invoking Claude model:', error);
       throw error;
     }
   }
@@ -152,7 +202,7 @@ class BedrockService {
     return sessionId;
   }
 
-  public async sendMessage(sessionId: string, message: string): Promise<string> {
+  public async sendMessage(sessionId: string, message: string, systemPrompt?: string): Promise<string> {
     const session = this.sessions.get(sessionId);
     if (!session) {
       throw new Error('Chat session not found');
@@ -164,11 +214,11 @@ class BedrockService {
       content: message,
     });
 
-    // Prepare context for the model
-    const context = this.prepareContext(session.messages);
-    
-    // Get response from Bedrock
-    const response = await this.invokeModel(context);
+    // Use healthcare system prompt by default, or allow custom override
+    const effectiveSystemPrompt = systemPrompt || getHealthcareSystemPrompt();
+
+    // Get response from Claude
+    const response = await this.invokeModel(session.messages, effectiveSystemPrompt);
 
     // Add assistant response to context
     session.messages.push({
@@ -181,19 +231,6 @@ class BedrockService {
     this.sessions.set(sessionId, session);
 
     return response;
-  }
-
-  private prepareContext(messages: ChatMessage[]): string {
-    // Format the conversation history into a prompt
-    const formattedMessages = messages.map(msg => {
-      const role = msg.role === 'assistant' ? 'Assistant' : 'Human';
-      return `${role}: ${msg.content}`;
-    });
-
-    // Add a final prompt for the assistant
-    formattedMessages.push('Assistant:');
-
-    return formattedMessages.join('\n');
   }
 
   public getChatSession(sessionId: string): ChatSession | undefined {


### PR DESCRIPTION
### Change

- Added a new healthcare-focused system prompt in BedrockService to guide AI responses.
- Updated invokeModel method to accept an optional system prompt, enhancing flexibility.
- Refactored response handling to accommodate Claude API responses instead of Bedrock.
- Removed dependency on husky.sh in the pre-push hook for improved script clarity.

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
