### PR TITLE
feat: Rename date field to createdAt in report mock data for consistency

### DIFF
--- a/frontend/src/pages/Home/components/ReportItem/__tests__/ReportItem.test.tsx
+++ b/frontend/src/pages/Home/components/ReportItem/__tests__/ReportItem.test.tsx
@@ -54,10 +54,8 @@ describe('ReportItem', () => {
     id: '1',
     title: 'Blood Test',
     category: ReportCategory.GENERAL,
-    date: '2025-01-27',
+    createdAt: '2025-01-27',
     status: ReportStatus.UNREAD,
-    doctor: 'Dr. Smith',
-    facility: 'City Hospital'
   };
 
   const mockReadReport: MedicalReport = {

--- a/frontend/src/pages/Upload/__tests__/UploadPage.test.tsx
+++ b/frontend/src/pages/Upload/__tests__/UploadPage.test.tsx
@@ -40,7 +40,7 @@ vi.mock('common/components/Upload/UploadModal', () => {
       id: '123',
       title: 'Test Report',
       category: ReportCategory.GENERAL,
-      date: '2023-01-01',
+      createdAt: '2023-01-01',
       status: ReportStatus.UNREAD,
     };
     


### PR DESCRIPTION
### Change

feat: Rename date field to createdAt in report mock data for consistency

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
