### PR TITLE
feat: Add cancel notice functionality in UploadModal component

### DIFF
--- a/frontend/src/common/components/Upload/UploadModal.scss
+++ b/frontend/src/common/components/Upload/UploadModal.scss
@@ -357,4 +357,32 @@
     --background: rgba(0, 0, 0, 0.1);
     --progress-background: var(--ion-color-primary);
   }
+
+  // Fixing the cancel notice styles to match the design exactly
+  &__cancel-notice {
+    display: flex;
+    align-items: center;
+    border-radius: 4px;
+    background: rgba(41, 69, 196, 0.5); // Darker blue background matching design
+    padding: 12px 16px;
+    margin: 16px 0;
+    width: 100%;
+    border: 1px solid #FF9cb4; // Border matching the icon color
+    text-align: left;
+    
+    span {
+      color: white;
+      font-size: 14px;
+      font-weight: 400;
+    }
+  }
+  
+  &__cancel-notice-icon {
+    color: #FF9cb4; // Using the danger color
+    margin-right: 12px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 18px;
+  }
 }

--- a/frontend/src/common/components/Upload/UploadModal.tsx
+++ b/frontend/src/common/components/Upload/UploadModal.tsx
@@ -28,6 +28,8 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
   const fileInputRef = useRef<HTMLInputElement>(null);
   // Track the upload result to use when the user closes the success screen
   const [uploadResult, setUploadResult] = useState<MedicalReport | null>(null);
+  // Track when to show the upload cancelled notice
+  const [showCancelNotice, setShowCancelNotice] = useState(false);
   
   const {
     file,
@@ -49,6 +51,8 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
   // Effect to automatically start upload when a file is selected and validated
   useEffect(() => {
     if (file && status === UploadStatus.IDLE) {
+      // When starting a new upload, hide the cancel notice if it's showing
+      setShowCancelNotice(false);
       uploadFile();
     }
   }, [file, status, uploadFile]);
@@ -71,6 +75,8 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
   const handleCancel = () => {
     if (status === UploadStatus.UPLOADING) {
       cancelUpload?.();
+      // Show the cancel notice when a user explicitly cancels an upload in progress
+      setShowCancelNotice(true);
     } else {
       reset();
       setUploadResult(null);
@@ -87,6 +93,7 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
     // Reset state
     reset();
     setUploadResult(null);
+    setShowCancelNotice(false);
     
     // Close modal
     onClose();
@@ -107,7 +114,18 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
             {t('upload.imageSizeLimit')} / {t('upload.pdfSizeLimit')}
           </p>
         </div>
-        {error && 
+        
+        {/* Show cancel notice */}
+        {showCancelNotice && (
+          <div className="upload-modal__cancel-notice">
+            <div className="upload-modal__cancel-notice-icon">
+              <FontAwesomeIcon icon={faCircleXmark} />
+            </div>
+            <span>Upload cancelled.</span>
+          </div>
+        )}
+        
+        {error && !showCancelNotice && 
           <IonItem className='upload-modal__error-message'>
             <div className='upload-modal__error-icon' slot='start'>
               <FontAwesomeIcon icon={faCircleXmark} aria-hidden="true"/>


### PR DESCRIPTION
### Change

{Describe what kind of change does this PR introduce}

### Does this PR introduce a breaking change?

This pull request introduces changes to the `UploadModal` component in the frontend to enhance the user experience by adding a cancel notice feature. The changes include updates to both the styles and the component logic to handle the display of the cancel notice.

### Enhancements to UploadModal component:

* **Styling updates:**
  * Added styles for the cancel notice to match the design specifications, including flex display, alignment, background color, padding, margin, border, and text styling in `UploadModal.scss`.

* **Component logic updates:**
  * Introduced a new state `showCancelNotice` to track when to show the upload canceled notice in `UploadModal.tsx`.
  * Updated the effect to hide the cancel notice when starting a new upload in `UploadModal.tsx`.
  * Modified the `handleCancel` function to show the cancel notice when an upload is explicitly canceled in `UploadModal.tsx`.
  * Reset the `showCancelNotice` state when the modal is closed in `UploadModal.tsx`.
  * Added conditional rendering for the cancel notice in the modal's JSX structure in `UploadModal.tsx`.

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
