### PR TITLE
[ADE-66] process reports asynchronously

### DIFF
--- a/backend/src/document-processor/controllers/document-processor.controller.ts
+++ b/backend/src/document-processor/controllers/document-processor.controller.ts
@@ -39,7 +39,7 @@ export class DocumentProcessorController {
 
   @Post('upload')
   @UseInterceptors(FileInterceptor('file'))
-  async processDocument(
+  async uploadAndProcessReport(
     @UploadedFile() file: Express.Multer.File,
     @Body('userId') userId: string,
     @Body('debug') debug?: string,
@@ -115,12 +115,12 @@ export class DocumentProcessorController {
   }
 
   @Post('process-file')
-  async processFileFromPath(
-    @Body('filePath') filePath: string,
+  async processReport(
+    @Body('reportId') reportId: string,
     @Req() request: RequestWithUser,
-  ): Promise<ProcessedDocumentResult | any> {
-    if (!filePath) {
-      throw new BadRequestException('No filePath provided');
+  ): Promise<any> {
+    if (!reportId) {
+      throw new BadRequestException('No reportId provided');
     }
 
     // Extract userId from the request (attached by auth middleware)
@@ -129,20 +129,69 @@ export class DocumentProcessorController {
       throw new UnauthorizedException('User ID not found in request');
     }
 
-    this.logger.log(`Processing document from file path: ${filePath}`);
+    this.logger.log(`Queueing document for processing, report ID: ${reportId}`);
 
     try {
-      // Fetch the associated report record from DynamoDB
-      const report = await this.reportsService.findByFilePath(filePath, userId);
+      // Fetch the associated report record from DynamoDB using findOne method
+      const report = await this.reportsService.findOne(reportId, userId);
       if (!report) {
-        throw new NotFoundException(`Report with filePath ${filePath} not found`);
+        throw new NotFoundException(`Report with ID ${reportId} not found`);
       }
+
+      // Make sure we have a filePath to retrieve the file
+      if (!report.filePath) {
+        throw new BadRequestException(`Report with ID ${reportId} has no associated file`);
+      }
+
+      // Update report status to IN_PROGRESS before starting async processing
+      report.processingStatus = ProcessingStatus.IN_PROGRESS;
+      report.updatedAt = new Date().toISOString();
+      await this.reportsService.updateReport(report);
+
+      // Start async processing in background
+      this.processReportAsync(reportId, userId, report.filePath).catch(error => {
+        this.logger.error(`Async processing failed for report ${reportId}: ${error.message}`);
+      });
+
+      return {
+        success: true,
+        reportId: report.id,
+        status: ProcessingStatus.IN_PROGRESS,
+        message: 'Document processing started. Check the report status to know when it completes.',
+      };
+    } catch (error: unknown) {
+      this.logger.error(
+        `Error queueing document for report ID ${reportId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * Processes a report file asynchronously
+   * @param reportId - ID of the report to process
+   * @param userId - ID of the user who owns the report
+   * @param filePath - S3 path to the file
+   */
+  private async processReportAsync(
+    reportId: string,
+    userId: string,
+    filePath: string,
+  ): Promise<void> {
+    try {
+      this.logger.log(`Started async processing for report: ${reportId}`);
 
       // Get the file from S3
       const fileBuffer = await this.getFileFromS3(filePath);
 
       // Process the document
       const result = await this.documentProcessorService.processDocument(fileBuffer, userId);
+
+      // Fetch the report again to ensure we have the latest version
+      const report = await this.reportsService.findOne(reportId, userId);
+      if (!report) {
+        throw new Error(`Report ${reportId} not found during async processing`);
+      }
 
       // Update the report with analysis results
       report.title = result.analysis.title || 'Untitled Report';
@@ -163,13 +212,26 @@ export class DocumentProcessorController {
       // Update the report in DynamoDB
       await this.reportsService.updateReport(report);
 
-      return {
-        success: true,
-        reportId: report.id,
-      };
-    } catch (error: unknown) {
+      this.logger.log(`Completed async processing for report: ${reportId}`);
+    } catch (error) {
+      // If processing fails, update the report status to indicate failure
+      try {
+        const report = await this.reportsService.findOne(reportId, userId);
+        if (report) {
+          report.processingStatus = ProcessingStatus.UNPROCESSED; // Could add a FAILED status in the enum if needed
+          report.updatedAt = new Date().toISOString();
+          await this.reportsService.updateReport(report);
+        }
+      } catch (updateError: unknown) {
+        this.logger.error(
+          `Failed to update report status after processing error: ${
+            updateError instanceof Error ? updateError.message : 'Unknown error'
+          }`,
+        );
+      }
+
       this.logger.error(
-        `Error processing document from path ${filePath}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        `Error during async processing for report ${reportId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
       );
       throw error;
     }
@@ -606,5 +668,43 @@ export class DocumentProcessorController {
     `;
 
     res.type('text/html').send(html);
+  }
+
+  @Get('report-status/:reportId')
+  async getReportStatus(
+    @Req() request: RequestWithUser,
+    @Body('reportId') idFromBody: string,
+  ): Promise<any> {
+    // Get reportId from path parameter or body
+    const reportId = request.params.reportId || idFromBody;
+
+    if (!reportId) {
+      throw new BadRequestException('No reportId provided');
+    }
+
+    // Extract userId from the request (attached by auth middleware)
+    const userId = request.user?.sub;
+    if (!userId) {
+      throw new UnauthorizedException('User ID not found in request');
+    }
+
+    try {
+      // Fetch the associated report record from DynamoDB
+      const report = await this.reportsService.findOne(reportId, userId);
+      if (!report) {
+        throw new NotFoundException(`Report with ID ${reportId} not found`);
+      }
+
+      return {
+        reportId: report.id,
+        status: report.processingStatus,
+        isComplete: report.processingStatus === ProcessingStatus.PROCESSED,
+      };
+    } catch (error: unknown) {
+      this.logger.error(
+        `Error fetching report status for ${reportId}: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      );
+      throw error;
+    }
   }
 }

--- a/backend/src/document-processor/controllers/document-processor.controller.ts
+++ b/backend/src/document-processor/controllers/document-processor.controller.ts
@@ -25,6 +25,7 @@ import { RequestWithUser } from '../../auth/auth.middleware';
 import { Readable } from 'stream';
 import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
 import { ConfigService } from '@nestjs/config';
+import { ProcessingStatus } from '../../reports/models/report.model';
 
 @Controller('document-processor')
 export class DocumentProcessorController {
@@ -146,7 +147,7 @@ export class DocumentProcessorController {
       // Update the report with analysis results
       report.title = result.analysis.title || 'Untitled Report';
       report.category = result.analysis.category || 'general';
-      report.isProcessed = true;
+      report.processingStatus = ProcessingStatus.PROCESSED;
 
       // Extract lab values
       report.labValues = result.analysis.labValues || [];

--- a/backend/src/iac/backend-stack.ts
+++ b/backend/src/iac/backend-stack.ts
@@ -405,7 +405,6 @@ export class BackendStack extends cdk.Stack {
     const integrationOptions = {
       connectionType: apigateway.ConnectionType.VPC_LINK,
       vpcLink: vpcLink,
-      timeout: cdk.Duration.seconds(300), // Adding 5-minute timeout (300 seconds)
     };
 
     const getDocsIntegration = new apigateway.Integration({

--- a/backend/src/reports/models/report.model.ts
+++ b/backend/src/reports/models/report.model.ts
@@ -5,6 +5,12 @@ export enum ReportStatus {
   READ = 'READ',
 }
 
+export enum ProcessingStatus {
+  PROCESSED = 'processed',
+  UNPROCESSED = 'unprocessed',
+  IN_PROGRESS = 'in_progress',
+}
+
 export class Report {
   @ApiProperty({ description: 'Unique identifier for the report' })
   id: string;
@@ -21,8 +27,12 @@ export class Report {
   @ApiProperty({ description: 'Category of the report' })
   category: string;
 
-  @ApiProperty({ description: 'Whether the report has been processed' })
-  isProcessed: boolean;
+  @ApiProperty({
+    description: 'Processing status of the report',
+    enum: ProcessingStatus,
+    default: ProcessingStatus.UNPROCESSED,
+  })
+  processingStatus: ProcessingStatus;
 
   @ApiProperty({ description: 'List of lab values' })
   labValues: Array<{

--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -15,7 +15,7 @@ import {
   QueryCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
-import { Report, ReportStatus } from './models/report.model';
+import { Report, ReportStatus, ProcessingStatus } from './models/report.model';
 import { GetReportsQueryDto } from './dto/get-reports.dto';
 import { UpdateReportStatusDto } from './dto/update-report-status.dto';
 import { v4 as uuidv4 } from 'uuid';
@@ -299,7 +299,7 @@ export class ReportsService {
         title: 'New Report',
         bookmarked: false,
         category: '',
-        isProcessed: false,
+        processingStatus: ProcessingStatus.UNPROCESSED,
         labValues: [],
         summary: '',
         status: ReportStatus.UNREAD,

--- a/frontend/src/common/api/reportService.ts
+++ b/frontend/src/common/api/reportService.ts
@@ -1,5 +1,5 @@
 import axios, { AxiosProgressEvent } from 'axios';
-import { MedicalReport, ReportCategory, ReportStatus } from '../models/medicalReport';
+import { MedicalReport, ReportCategory, ReportStatus, ProcessingStatus } from '../models/medicalReport';
 import { fetchAuthSession } from '@aws-amplify/auth';
 // Get the API URL from environment variables
 const API_URL = import.meta.env.VITE_BASE_URL_API || '';
@@ -12,7 +12,7 @@ const mockReports: MedicalReport[] = [
     title: 'Blood Test Report',
     category: ReportCategory.GENERAL,
     bookmarked: false,
-    isProcessed: true,
+    processingStatus: ProcessingStatus.PROCESSED,
     labValues: [],
     summary: 'Blood test results within normal range',
     status: ReportStatus.UNREAD,
@@ -26,7 +26,7 @@ const mockReports: MedicalReport[] = [
     title: 'Heart Checkup',
     category: ReportCategory.HEART,
     bookmarked: true,
-    isProcessed: true,
+    processingStatus: ProcessingStatus.PROCESSED,
     labValues: [],
     summary: 'Heart functioning normally',
     status: ReportStatus.READ,

--- a/frontend/src/common/components/Upload/UploadModal.tsx
+++ b/frontend/src/common/components/Upload/UploadModal.tsx
@@ -63,10 +63,10 @@ const UploadModal = ({ isOpen, onClose, onUploadComplete }: UploadModalProps): J
         if (onUploadComplete) {
           onUploadComplete(result);
         }
-        // Navigate to the processing tab with filePath in state
+        // Navigate to the processing tab with reportId in state
         if (file) {
           history.push('/tabs/processing', {
-            filePath: result.filePath,
+            reportId: result.id,
           });
         } else {
           history.push('/tabs/processing');

--- a/frontend/src/common/models/medicalReport.ts
+++ b/frontend/src/common/models/medicalReport.ts
@@ -15,8 +15,17 @@ export enum ReportCategory {
  * Status of a medical report.
  */
 export enum ReportStatus {
+  UNREAD = 'UNREAD',
   READ = 'READ',
-  UNREAD = 'UNREAD'
+}
+
+/**
+ * Processing status of a medical report.
+ */
+export enum ProcessingStatus {
+  PROCESSED = 'processed',
+  UNPROCESSED = 'unprocessed',
+  IN_PROGRESS = 'in_progress',
 }
 
 /**
@@ -42,7 +51,7 @@ export interface MedicalReport {
   title: string;
   category: ReportCategory | string;
   bookmarked: boolean;
-  isProcessed: boolean;
+  processingStatus: ProcessingStatus;
   labValues: LabValue[];
   summary: string;
   status: ReportStatus;

--- a/frontend/src/pages/Processing/Processing.tsx
+++ b/frontend/src/pages/Processing/Processing.tsx
@@ -2,7 +2,7 @@ import { IonContent, IonPage } from '@ionic/react';
 import { useCurrentUser } from '../../common/hooks/useAuth';
 import Avatar from '../../common/components/Icon/Avatar';
 import { useLocation, useHistory } from 'react-router-dom';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { useAxios } from '../../common/hooks/useAxios';
 import './Processing.scss';
 import { getAuthConfig } from 'common/api/reportService';
@@ -21,22 +21,62 @@ const Processing: React.FC = () => {
   // States to track processing
   const [isProcessing, setIsProcessing] = useState(true);
   const [processingError, setProcessingError] = useState<string | null>(null);
+  const statusCheckIntervalRef = useRef<number | null>(null);
 
-  // Get the location state which may contain the filePath
-  const location = useLocation<{ filePath: string }>();
-  const filePath = location.state?.filePath;
-  const [reportId, setReportId] = useState(null);
+  // Get the location state which may contain the reportId (previously filePath)
+  const location = useLocation<{ reportId: string }>();
+  const reportId = location.state?.reportId;
   const [isFetching, setIsFetching] = useState(false);
+
+  // Check the status of the report processing
+  const checkReportStatus = async () => {
+    if (!reportId) return;
+
+    try {
+      const response = await axios.get(
+        `${API_URL}/api/document-processor/report-status/${reportId}`,
+        await getAuthConfig(),
+      );
+
+      console.log('Report status:', response.data);
+
+      // If processing is complete, clear the interval and redirect to the report page
+      if (response.data.isComplete) {
+        setIsProcessing(false);
+
+        // Clear the interval
+        if (statusCheckIntervalRef.current) {
+          window.clearInterval(statusCheckIntervalRef.current);
+          statusCheckIntervalRef.current = null;
+        }
+
+        console.log('Processing complete');
+
+        // Redirect to report detail page
+        history.push(`/tabs/reports/${reportId}`);
+      }
+    } catch (error) {
+      console.error('Error checking report status:', error);
+      setProcessingError('Failed to check the status of the report. Please try again.');
+      setIsProcessing(false);
+
+      // Clear the interval on error
+      if (statusCheckIntervalRef.current) {
+        window.clearInterval(statusCheckIntervalRef.current);
+        statusCheckIntervalRef.current = null;
+      }
+    }
+  };
 
   // Send the API request when component mounts
   useEffect(() => {
-    if (!filePath) {
-      setProcessingError('No file path provided');
+    if (!reportId) {
+      setProcessingError('No report ID provided');
       setIsProcessing(false);
       return;
     }
 
-    if (reportId && isFetching) {
+    if (isFetching) {
       return;
     }
 
@@ -47,12 +87,17 @@ const Processing: React.FC = () => {
         // Send POST request to backend API
         const response = await axios.post(
           `${API_URL}/api/document-processor/process-file`,
-          { filePath },
+          { reportId },
           await getAuthConfig(),
         );
-        setReportId(response.data.reportId);
 
-        console.log('File processed successfully:', response.data);
+        console.log('File processing started:', response.data);
+
+        // Start checking the status every 5 seconds
+        statusCheckIntervalRef.current = window.setInterval(checkReportStatus, 5000);
+
+        // Run the first status check immediately
+        checkReportStatus();
       } catch (error) {
         console.error('Error processing file:', error);
         setProcessingError('Failed to process the file. Please try again.');
@@ -61,7 +106,14 @@ const Processing: React.FC = () => {
     };
 
     processFile();
-  }, [filePath, axios, history]);
+
+    // Clean up the interval when the component unmounts
+    return () => {
+      if (statusCheckIntervalRef.current) {
+        window.clearInterval(statusCheckIntervalRef.current);
+      }
+    };
+  }, [reportId, axios, history]);
 
   return (
     <IonPage className="processing-page">

--- a/frontend/src/pages/Upload/__tests__/UploadPage.test.tsx
+++ b/frontend/src/pages/Upload/__tests__/UploadPage.test.tsx
@@ -2,7 +2,7 @@ import { vi, describe, test, expect, beforeEach } from 'vitest';
 import { render, screen, fireEvent } from '@testing-library/react';
 import UploadPage from '../UploadPage';
 import { MemoryRouter } from 'react-router-dom';
-import { MedicalReport, ReportCategory, ReportStatus } from 'common/models/medicalReport';
+import { MedicalReport, ReportCategory, ReportStatus, ProcessingStatus } from 'common/models/medicalReport';
 import '@testing-library/jest-dom';
 
 // Mock the dependencies
@@ -48,7 +48,7 @@ vi.mock('common/components/Upload/UploadModal', () => {
       createdAt: '2023-01-01',
       status: ReportStatus.UNREAD,
       bookmarked: false,
-      isProcessed: true,
+      processingStatus: ProcessingStatus.PROCESSED,
       labValues: [],
       summary: 'Test report summary',
       filePath: '/reports/test-report.pdf',


### PR DESCRIPTION
### Change

This pull request introduces significant changes to the document processing workflow, transitioning from a file-path-based system to a report-ID-based system. It also introduces a new `ProcessingStatus` enum to track the state of report processing and implements asynchronous processing with status checks. Below are the most important changes grouped by theme:

### Backend Changes

* **Document Processing Workflow Updates**:
  - Replaced `filePath` with `reportId` in methods like `processReport` and added validation to ensure the report exists and has an associated file path. Updated the report's processing status to `IN_PROGRESS` before starting asynchronous processing. [[1]](diffhunk://#diff-d447fd4ea0593ae5a76e621fc7bce2d97e41ec8981273a5c1db2ae765d303157L117-R123) [[2]](diffhunk://#diff-d447fd4ea0593ae5a76e621fc7bce2d97e41ec8981273a5c1db2ae765d303157L131-R199)
  - Added a new `processReportAsync` method to handle document processing in the background and update the report's status to `PROCESSED` or handle errors by marking it as `UNPROCESSED`. [[1]](diffhunk://#diff-d447fd4ea0593ae5a76e621fc7bce2d97e41ec8981273a5c1db2ae765d303157L131-R199) [[2]](diffhunk://#diff-d447fd4ea0593ae5a76e621fc7bce2d97e41ec8981273a5c1db2ae765d303157L165-R234)

* **New Endpoint for Report Status**:
  - Introduced a `getReportStatus` endpoint to fetch the processing status of a report using its `reportId`.

* **Model Enhancements**:
  - Added a `ProcessingStatus` enum (`PROCESSED`, `UNPROCESSED`, `IN_PROGRESS`) and replaced the `isProcessed` boolean with a `processingStatus` field in the `Report` model. [[1]](diffhunk://#diff-6f31e7a7ef0fedc1f210f18e9bb6d163faeda4f13d64f20ef5b32638a0161cc5R8-R13) [[2]](diffhunk://#diff-6f31e7a7ef0fedc1f210f18e9bb6d163faeda4f13d64f20ef5b32638a0161cc5L24-R35)

### Frontend Changes

* **Processing Page Updates**:
  - Updated the `Processing` page to use `reportId` instead of `filePath`. Added periodic status checks via a new `checkReportStatus` function and redirected users to the report detail page once processing is complete. [[1]](diffhunk://#diff-d44d21544843f462db7189b68e1d21d830c619226b21d4feddafe6676e4a2e5aR24-R79) [[2]](diffhunk://#diff-d44d21544843f462db7189b68e1d21d830c619226b21d4feddafe6676e4a2e5aL50-R100) [[3]](diffhunk://#diff-d44d21544843f462db7189b68e1d21d830c619226b21d4feddafe6676e4a2e5aL64-R116)

* **Model and Mock Data Updates**:
  - Updated the `MedicalReport` model to include `processingStatus` instead of `isProcessed`. Adjusted mock data and tests accordingly. [[1]](diffhunk://#diff-83c804b1de0db6fac4836f5932b3b3a78ef14b0f8d535b4172cdaec436c6fd24L15-R15) [[2]](diffhunk://#diff-83c804b1de0db6fac4836f5932b3b3a78ef14b0f8d535b4172cdaec436c6fd24L29-R29) [[3]](diffhunk://#diff-10a5dbd3286548c3f0864cbf77a14808ac6192fcc050f285818d883c76614cb6L45-R54) [[4]](diffhunk://#diff-a8208a5ef00b1b26ad5321cf670520f1a3d94900d1bf8cfba0ddaba072fcc834L51-R51)

### Miscellaneous

* **Code Cleanup**:
  - Removed unused timeout configuration in the API Gateway integration options.

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
