### PR TITLE
[ADE-66] Add ReportMetadata interface and internationalize missing reference ranges message in reports

### DIFF
--- a/frontend/src/common/models/medicalReport.ts
+++ b/frontend/src/common/models/medicalReport.ts
@@ -40,6 +40,15 @@ export interface LabValue {
 }
 
 /**
+ * Interface for report metadata.
+ */
+export interface ReportMetadata {
+  isMedicalReport: boolean;
+  confidence: number;
+  missingInformation: string[];
+}
+
+/**
  * Interface representing a medical report.
  */
 export interface MedicalReport {
@@ -60,4 +69,5 @@ export interface MedicalReport {
   isMedicalReport?: boolean; // Optional flag to indicate if the report is a medical report
   createdAt: string; // ISO date string
   updatedAt: string; // ISO date string
+  metadata?: ReportMetadata; // Optional metadata for the report
 }

--- a/frontend/src/common/utils/i18n/resources/en/reportDetail.json
+++ b/frontend/src/common/utils/i18n/resources/en/reportDetail.json
@@ -89,5 +89,8 @@
       "ai-insights": "AI Insights",
       "original-report": "Original Report"
     }
+  },
+  "reports": {
+    "missingReferenceRanges": "Reference ranges were not available on this report. The analysis may be limited without this information. Please consult with your healthcare provider for a complete interpretation."
   }
 }

--- a/frontend/src/common/utils/i18n/resources/es/report.json
+++ b/frontend/src/common/utils/i18n/resources/es/report.json
@@ -64,5 +64,8 @@
     "general": "General",
     "heart": "Corazón",
     "brain": "Cerebro"
+  },
+  "reports": {
+    "missingReferenceRanges": "Los rangos de referencia no estaban disponibles en este informe. El análisis puede ser limitado sin esta información. Por favor, consulte con su proveedor de atención médica para una interpretación completa."
   }
 }

--- a/frontend/src/common/utils/i18n/resources/fr/report.json
+++ b/frontend/src/common/utils/i18n/resources/fr/report.json
@@ -64,5 +64,8 @@
     "general": "Général",
     "heart": "Cœur",
     "brain": "Cerveau"
+  },
+  "reports": {
+    "missingReferenceRanges": "Les plages de référence n'étaient pas disponibles dans ce rapport. L'analyse peut être limitée sans cette information. Veuillez consulter votre professionnel de la santé pour une interprétation complète."
   }
 }

--- a/frontend/src/pages/Reports/components/AiAnalysisTab.tsx
+++ b/frontend/src/pages/Reports/components/AiAnalysisTab.tsx
@@ -4,6 +4,7 @@ import EmergencyAlert from './EmergencyAlert';
 import FlaggedValuesSection from './FlaggedValuesSection';
 import NormalValuesSection from './NormalValuesSection';
 import LowConfidenceNotice from './LowConfidenceNotice';
+import MissingReferenceRangesNotice from './MissingReferenceRangesNotice';
 
 interface AiAnalysisTabProps {
   reportData: MedicalReport;
@@ -35,6 +36,9 @@ const AiAnalysisTab: React.FC<AiAnalysisTabProps> = ({
   const confidenceScore = reportData.confidence;
 
   const isLowConfidence = confidenceScore < 0.75;
+  
+  // Check if reference ranges are missing
+  const hasReferenceRangesMissing = reportData.metadata?.missingInformation?.includes('reference-ranges-missing');
 
   return (
     <div className="ai-analysis-tab">
@@ -43,6 +47,9 @@ const AiAnalysisTab: React.FC<AiAnalysisTabProps> = ({
 
       {/* Low confidence notice */}
       {isLowConfidence && <LowConfidenceNotice />}
+      
+      {/* Missing reference ranges notice */}
+      {hasReferenceRangesMissing && <MissingReferenceRangesNotice />}
 
       {/* Flagged values section */}
       {flaggedValues.length > 0 && (

--- a/frontend/src/pages/Reports/components/MissingReferenceRangesNotice.tsx
+++ b/frontend/src/pages/Reports/components/MissingReferenceRangesNotice.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import info from '../../../assets/icons/info.svg';
+
+/**
+ * Component to display a notice when reference ranges are missing from the report
+ */
+const MissingReferenceRangesNotice: React.FC = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className="low-confidence-notice">
+      <div className="notice-icon">
+        <img src={info} alt="Information Icon" />
+      </div>
+      <div className="notice-text">
+        {t('reports.missingReferenceRanges', {
+          ns: 'reportDetail',
+          defaultValue:
+            'Reference ranges were not available on this report. The analysis may be limited without this information. Please consult with your healthcare provider for a complete interpretation.',
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default MissingReferenceRangesNotice; 


### PR DESCRIPTION
### Change

- Add ReportMetadata interface and internationalize missing reference ranges message in reports
- Introduced ReportMetadata interface in frontend/src/common/models/medicalReport.ts to encapsulate metadata related to medical reports.
- Added internationalized message for missing reference ranges in English, Spanish, and French translation files.
- Updated AiAnalysisTab component to display a notice when reference ranges are missing.

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
