### PR TITLE
Update reportService API endpoint for marking reports as read

### DIFF
--- a/backend/src/reports/reports.service.ts
+++ b/backend/src/reports/reports.service.ts
@@ -243,7 +243,10 @@ export class ReportsService {
 
       const command = new UpdateItemCommand({
         TableName: this.tableName,
-        Key: marshall({ id }),
+        Key: marshall({
+          userId, // Partition key
+          id, // Sort key
+        }),
         UpdateExpression: 'SET #status = :status, updatedAt = :updatedAt',
         ConditionExpression: 'userId = :userId', // Ensure the report belongs to the user
         ExpressionAttributeNames: {

--- a/frontend/src/common/api/__tests__/reportService.test.ts
+++ b/frontend/src/common/api/__tests__/reportService.test.ts
@@ -103,7 +103,7 @@ vi.mock('../reportService', async (importOriginal) => {
     // Mock markReportAsRead to avoid the dependency on getAuthConfig
     markReportAsRead: async (reportId: string) => {
       try {
-        const response = await axios.patch(`/api/reports/${reportId}`, {
+        const response = await axios.patch(`/api/reports/${reportId}/status`, {
           status: 'READ',
         });
         return response.data;

--- a/frontend/src/common/api/reportService.ts
+++ b/frontend/src/common/api/reportService.ts
@@ -142,7 +142,7 @@ export const fetchAllReports = async (): Promise<MedicalReport[]> => {
 export const markReportAsRead = async (reportId: string): Promise<MedicalReport> => {
   try {
     const response = await axios.patch(
-      `${API_URL}/api/reports/${reportId}`,
+      `${API_URL}/api/reports/${reportId}/status`,
       {
         status: 'READ',
       },


### PR DESCRIPTION
### Change

This pull request includes updates to the `ReportsService` in the backend and changes to the API endpoints and their usage in the frontend. The most important changes involve modifying the DynamoDB key structure in the backend and updating the API endpoint for marking reports as read in the frontend.

### Backend changes:
* Updated the `ReportsService` in `reports.service.ts` to use a composite key (`userId` as the partition key and `id` as the sort key) for DynamoDB operations, ensuring better data organization and query flexibility.

### Frontend changes:
* Updated the API endpoint for marking reports as read by appending `/status` to the URL in `reportService.test.ts` and `reportService.ts`, aligning it with the new backend API structure. [[1]](diffhunk://#diff-bbd513a14ebe42d4142dd925ff9996c50a68483339680a30dc5029c0c17f5446L106-R106) [[2]](diffhunk://#diff-83c804b1de0db6fac4836f5932b3b3a78ef14b0f8d535b4172cdaec436c6fd24L145-R145)

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
