### PR TITLE
[ADE-67] Discard and Upload new Report functionality

### DIFF
--- a/frontend/src/common/components/Modal/ConfirmationModal.scss
+++ b/frontend/src/common/components/Modal/ConfirmationModal.scss
@@ -1,0 +1,84 @@
+.confirmation-modal {
+  --height: auto;
+  --border-radius: 16px 16px 0 0;
+  --box-shadow: none;
+  align-items: flex-end;
+  --background: #ffffff;
+
+  &__container {
+    padding: 24px;
+    width: 100%;
+  }
+
+  &__title {
+    font-family: 'Inter', sans-serif;
+    font-size: 22px;
+    font-weight: 600;
+    color: #313e4c;
+    margin: 0 0 16px;
+    text-align: left;
+  }
+
+  &__message {
+    font-family: 'Inter', sans-serif;
+    font-size: 16px;
+    font-weight: 400;
+    color: #313e4c;
+    margin: 0 0 24px;
+    text-align: left;
+    line-height: 1.5;
+  }
+
+  &__actions {
+    display: flex;
+    gap: 16px;
+  }
+
+  &__button {
+    flex: 1;
+    min-height: 56px;
+    margin: 0;
+    --border-radius: 12px;
+    font-size: 20px;
+    font-weight: 600;
+    text-transform: none;
+    
+    &--cancel {
+      --background: #ffffff;
+      --background-hover: rgba(67, 95, 240, 0.04);
+      --background-activated: rgba(67, 95, 240, 0.08);
+      --color: #435ff0; /* Blue color for No button */
+      --border-color: #435ff0;
+      --border-width: 1px;
+      --border-style: solid;
+      --box-shadow: none;
+    }
+    
+    &--confirm {
+      --background: #ffffff; /* White background for Yes button */
+      --background-hover: rgba(175, 27, 63, 0.04);
+      --background-activated: rgba(175, 27, 63, 0.08);
+      --color: #af1b3f; /* Red color for Yes button */
+      --border-color: #af1b3f; /* Red border for Yes button */
+      --border-width: 1px;
+      --border-style: solid;
+    }
+  }
+
+  // Media queries for larger screens
+  @media screen and (min-width: 768px) {
+    &__container {
+      max-width: 500px;
+      margin: 0 auto;
+    }
+  }
+
+  // Handle the pull indicator
+  &::part(handle) {
+    background: #D9D9D9;
+    width: 36px;
+    height: 4px;
+    border-radius: 2px;
+    margin-top: 12px;
+  }
+}

--- a/frontend/src/common/components/Modal/ConfirmationModal.tsx
+++ b/frontend/src/common/components/Modal/ConfirmationModal.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { IonButton, IonModal } from '@ionic/react';
+import './ConfirmationModal.scss';
+
+interface ConfirmationModalProps {
+  isOpen: boolean;
+  title: string;
+  message: string;
+  confirmText: string;
+  cancelText: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  itemName?: string;
+  testid?: string;
+}
+
+/**
+ * A reusable confirmation modal component that presents as a bottom sheet
+ * Used for confirming destructive actions like deleting or discarding items
+ */
+const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
+  isOpen,
+  title,
+  message,
+  confirmText,
+  cancelText,
+  onConfirm,
+  onCancel,
+  itemName,
+  testid = 'confirmation-modal',
+}) => {
+  // Replace placeholder with actual item name if provided
+  const formattedMessage = itemName 
+    ? message.replace('{itemName}', `"${itemName}"`)
+    : message;
+    
+  return (
+    <IonModal
+      isOpen={isOpen}
+      onDidDismiss={onCancel}
+      className="confirmation-modal"
+      data-testid={testid}
+    >
+      <div className="confirmation-modal__container">
+        <h2 className="confirmation-modal__title">{title}</h2>
+        
+        <p className="confirmation-modal__message">
+          {formattedMessage}
+        </p>
+        
+        <div className="confirmation-modal__actions">
+          <IonButton
+            expand="block"
+            fill="outline"
+            className="confirmation-modal__button confirmation-modal__button--cancel"
+            onClick={onCancel}
+            data-testid={`${testid}-cancel`}
+          >
+            {cancelText}
+          </IonButton>
+          
+          <IonButton
+            expand="block"
+            fill="outline"
+            className="confirmation-modal__button confirmation-modal__button--confirm"
+            onClick={onConfirm}
+            data-testid={`${testid}-confirm`}
+          >
+            {confirmText}
+          </IonButton>
+        </div>
+      </div>
+    </IonModal>
+  );
+};
+
+export default ConfirmationModal;

--- a/frontend/src/common/utils/i18n/resources/en/common.json
+++ b/frontend/src/common/utils/i18n/resources/en/common.json
@@ -73,10 +73,10 @@
   "loading": {
     "report": "Loading report..."
   },
-  "no": "no",
+  "no": "No",
   "updated": "updated",
   "welcome": "Welcome",
-  "yes": "yes",
+  "yes": "Yes",
   "pages": {
     "chat": {
       "title": "AI Assistant"

--- a/frontend/src/common/utils/i18n/resources/es/common.json
+++ b/frontend/src/common/utils/i18n/resources/es/common.json
@@ -70,10 +70,10 @@
   "loading": {
     "report": "Cargando informe..."
   },
-  "no": "no",
+  "no": "No",
   "updated": "actualizado",
   "welcome": "Bienvenido",
-  "yes": "sí",
+  "yes": "Sí",
   "pages": {
     "chat": {
       "title": "Asistente IA"

--- a/frontend/src/common/utils/i18n/resources/fr/common.json
+++ b/frontend/src/common/utils/i18n/resources/fr/common.json
@@ -70,10 +70,10 @@
   "loading": {
     "report": "Chargement du rapport..."
   },
-  "no": "non",
+  "no": "Non",
   "updated": "mis à jour",
   "welcome": "Bienvenu",
-  "yes": "oui",
+  "yes": "Oui",
   "pages": {
     "chat": {
       "title": "Assistant IA"

--- a/frontend/src/pages/Reports/ReportDetailPage.tsx
+++ b/frontend/src/pages/Reports/ReportDetailPage.tsx
@@ -89,24 +89,24 @@ const ReportDetailPage: React.FC = () => {
   const handleDiscard = async () => {
     try {
       await axios.delete(`${API_URL}/api/reports/${reportId}`, await getAuthConfig());
-      
+
       // Show toast notification
       createToast({
-        message: t('report.discard.success', { 
-          ns: 'reportDetail', 
-          defaultValue: 'Report deleted successfully' 
+        message: t('report.discard.success', {
+          ns: 'reportDetail',
+          defaultValue: 'Report deleted successfully',
         }),
         duration: 2000,
       });
-      
+
       // Navigate back
       history.push('/tabs/home');
     } catch (error) {
       console.error('Error discarding report:', error);
       createToast({
-        message: t('report.discard.error', { 
-          ns: 'reportDetail', 
-          defaultValue: 'Failed to delete report' 
+        message: t('report.discard.error', {
+          ns: 'reportDetail',
+          defaultValue: 'Failed to delete report',
         }),
         duration: 2000,
         color: 'danger',
@@ -139,10 +139,11 @@ const ReportDetailPage: React.FC = () => {
         <InfoCard />
 
         {/* Action buttons at the bottom */}
-        <ActionButtons 
-          onDiscard={handleDiscard} 
+        <ActionButtons
+          onDiscard={handleDiscard}
           onNewUpload={handleNewUpload}
           reportTitle={reportData.title || reportData.category}
+          reportId={reportId}
         />
       </IonContent>
     </IonPage>

--- a/frontend/src/pages/Reports/ReportDetailPage.tsx
+++ b/frontend/src/pages/Reports/ReportDetailPage.tsx
@@ -7,6 +7,7 @@ import axios from 'axios';
 import { MedicalReport } from '../../common/models/medicalReport';
 import { useTranslation } from 'react-i18next';
 import { getAuthConfig } from 'common/api/reportService';
+import { useToasts } from 'common/hooks/useToasts';
 
 // Import components
 import ReportHeader from './components/ReportHeader';
@@ -35,6 +36,7 @@ const ReportDetailPage: React.FC = () => {
   const { reportId } = useParams<{ reportId: string }>();
   const history = useHistory();
   const { t } = useTranslation();
+  const { createToast } = useToasts();
 
   // Fetch report data using react-query
   const { data, isLoading, error } = useQuery<MedicalReport>({
@@ -85,8 +87,31 @@ const ReportDetailPage: React.FC = () => {
 
   // Handle action buttons
   const handleDiscard = async () => {
-    await axios.delete(`${API_URL}/api/reports/${reportId}`, await getAuthConfig());
-    history.push('/tabs/home');
+    try {
+      await axios.delete(`${API_URL}/api/reports/${reportId}`, await getAuthConfig());
+      
+      // Show toast notification
+      createToast({
+        message: t('report.discard.success', { 
+          ns: 'reportDetail', 
+          defaultValue: 'Report deleted successfully' 
+        }),
+        duration: 2000,
+      });
+      
+      // Navigate back
+      history.push('/tabs/home');
+    } catch (error) {
+      console.error('Error discarding report:', error);
+      createToast({
+        message: t('report.discard.error', { 
+          ns: 'reportDetail', 
+          defaultValue: 'Failed to delete report' 
+        }),
+        duration: 2000,
+        color: 'danger',
+      });
+    }
   };
 
   const handleNewUpload = () => {
@@ -114,7 +139,11 @@ const ReportDetailPage: React.FC = () => {
         <InfoCard />
 
         {/* Action buttons at the bottom */}
-        <ActionButtons onDiscard={handleDiscard} onNewUpload={handleNewUpload} />
+        <ActionButtons 
+          onDiscard={handleDiscard} 
+          onNewUpload={handleNewUpload}
+          reportTitle={reportData.title || reportData.category}
+        />
       </IonContent>
     </IonPage>
   );

--- a/frontend/src/pages/Reports/components/ActionButtons.tsx
+++ b/frontend/src/pages/Reports/components/ActionButtons.tsx
@@ -1,29 +1,62 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import ConfirmationModal from '../../../common/components/Modal/ConfirmationModal';
 
 interface ActionButtonsProps {
   onDiscard: () => void;
   onNewUpload: () => void;
+  reportTitle?: string;
 }
 
-const ActionButtons: React.FC<ActionButtonsProps> = ({ onDiscard, onNewUpload }) => {
+const ActionButtons: React.FC<ActionButtonsProps> = ({ onDiscard, onNewUpload, reportTitle = "" }) => {
   const { t } = useTranslation();
+  const [showConfirmDiscard, setShowConfirmDiscard] = useState(false);
+
+  const handleDiscardClick = () => {
+    setShowConfirmDiscard(true);
+  };
+
+  const handleConfirmDiscard = () => {
+    setShowConfirmDiscard(false);
+    onDiscard();
+  };
+
+  const handleCancelDiscard = () => {
+    setShowConfirmDiscard(false);
+  };
 
   return (
-    <div className="report-detail-page__actions">
-      <button
-        className="report-detail-page__action-button report-detail-page__action-button--discard"
-        onClick={onDiscard}
-      >
-        {t('report.action.discard', { ns: 'reportDetail' })}
-      </button>
-      <button
-        className="report-detail-page__action-button report-detail-page__action-button--upload"
-        onClick={onNewUpload}
-      >
-        {t('report.action.new-upload', { ns: 'reportDetail' })}
-      </button>
-    </div>
+    <>
+      <div className="report-detail-page__actions">
+        <button
+          className="report-detail-page__action-button report-detail-page__action-button--discard"
+          onClick={handleDiscardClick}
+        >
+          {t('report.action.discard', { ns: 'reportDetail' })}
+        </button>
+        <button
+          className="report-detail-page__action-button report-detail-page__action-button--upload"
+          onClick={onNewUpload}
+        >
+          {t('report.action.new-upload', { ns: 'reportDetail' })}
+        </button>
+      </div>
+
+      <ConfirmationModal 
+        isOpen={showConfirmDiscard}
+        title={t('report.discard.title', { ns: 'reportDetail', defaultValue: 'Discard report?' })}
+        message={t('report.discard.message', { 
+          ns: 'reportDetail', 
+          defaultValue: '{itemName} will be discarded and not be saved to your reports archive. Are you sure?' 
+        })}
+        confirmText={t('common:yes')}
+        cancelText={t('common:no')}
+        onConfirm={handleConfirmDiscard}
+        onCancel={handleCancelDiscard}
+        itemName={reportTitle}
+        testid="discard-report-confirmation"
+      />
+    </>
   );
 };
 

--- a/frontend/src/pages/Reports/components/ActionButtons.tsx
+++ b/frontend/src/pages/Reports/components/ActionButtons.tsx
@@ -1,16 +1,28 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import axios from 'axios';
+import { getAuthConfig } from 'common/api/reportService';
 import ConfirmationModal from '../../../common/components/Modal/ConfirmationModal';
+
+const API_URL = import.meta.env.VITE_BASE_URL_API || '';
 
 interface ActionButtonsProps {
   onDiscard: () => void;
   onNewUpload: () => void;
   reportTitle?: string;
+  reportId?: string;
 }
 
-const ActionButtons: React.FC<ActionButtonsProps> = ({ onDiscard, onNewUpload, reportTitle = "" }) => {
+const ActionButtons: React.FC<ActionButtonsProps> = ({
+  onDiscard,
+  onNewUpload,
+  reportTitle = '',
+  reportId,
+}) => {
   const { t } = useTranslation();
   const [showConfirmDiscard, setShowConfirmDiscard] = useState(false);
+  const [showConfirmNewUpload, setShowConfirmNewUpload] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const handleDiscardClick = () => {
     setShowConfirmDiscard(true);
@@ -25,29 +37,61 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ onDiscard, onNewUpload, r
     setShowConfirmDiscard(false);
   };
 
+  const handleNewUploadClick = () => {
+    setShowConfirmNewUpload(true);
+  };
+
+  const handleConfirmNewUpload = async () => {
+    setShowConfirmNewUpload(false);
+
+    // If we have a reportId, delete the current report before going to upload screen
+    if (reportId) {
+      try {
+        setIsDeleting(true);
+        await axios.delete(`${API_URL}/api/reports/${reportId}`, await getAuthConfig());
+      } catch (error) {
+        console.error('Error deleting report before new upload:', error);
+      } finally {
+        setIsDeleting(false);
+        // Even if delete failed, still go to upload screen
+        onNewUpload();
+      }
+    } else {
+      // If no reportId, just navigate to upload
+      onNewUpload();
+    }
+  };
+
+  const handleCancelNewUpload = () => {
+    setShowConfirmNewUpload(false);
+  };
+
   return (
     <>
       <div className="report-detail-page__actions">
         <button
           className="report-detail-page__action-button report-detail-page__action-button--discard"
           onClick={handleDiscardClick}
+          disabled={isDeleting}
         >
           {t('report.action.discard', { ns: 'reportDetail' })}
         </button>
         <button
           className="report-detail-page__action-button report-detail-page__action-button--upload"
-          onClick={onNewUpload}
+          onClick={handleNewUploadClick}
+          disabled={isDeleting}
         >
           {t('report.action.new-upload', { ns: 'reportDetail' })}
         </button>
       </div>
 
-      <ConfirmationModal 
+      <ConfirmationModal
         isOpen={showConfirmDiscard}
         title={t('report.discard.title', { ns: 'reportDetail', defaultValue: 'Discard report?' })}
-        message={t('report.discard.message', { 
-          ns: 'reportDetail', 
-          defaultValue: '{itemName} will be discarded and not be saved to your reports archive. Are you sure?' 
+        message={t('report.discard.message', {
+          ns: 'reportDetail',
+          defaultValue:
+            '{itemName} will be discarded and not be saved to your reports archive. Are you sure?',
         })}
         confirmText={t('common:yes')}
         cancelText={t('common:no')}
@@ -55,6 +99,24 @@ const ActionButtons: React.FC<ActionButtonsProps> = ({ onDiscard, onNewUpload, r
         onCancel={handleCancelDiscard}
         itemName={reportTitle}
         testid="discard-report-confirmation"
+      />
+
+      <ConfirmationModal
+        isOpen={showConfirmNewUpload}
+        title={t('report.new-upload.title', {
+          ns: 'reportDetail',
+          defaultValue: 'Upload new report?',
+        })}
+        message={t('report.new-upload.message', {
+          ns: 'reportDetail',
+          defaultValue:
+            "You've chosen to upload a new report. This will replace your current one. Do you still want to proceed?",
+        })}
+        confirmText={t('common:yes')}
+        cancelText={t('common:no')}
+        onConfirm={handleConfirmNewUpload}
+        onCancel={handleCancelNewUpload}
+        testid="new-upload-confirmation"
       />
     </>
   );


### PR DESCRIPTION
### Change

This pull request introduces a reusable `ConfirmationModal` component for confirmation dialogs, integrates it into the `ReportDetailPage` and `ActionButtons` components, and improves the user experience by adding toast notifications and confirmation modals for critical actions. It also includes minor updates to localization files for consistency in capitalization.

### New Reusable Component:
* Added a `ConfirmationModal` component (`frontend/src/common/components/Modal/ConfirmationModal.tsx`) with customizable title, message, and actions. This component is styled as a bottom sheet and supports dynamic content replacement. [[1]](diffhunk://#diff-d9a6dcce0fec3b6ab37592e1dedfa3bd6874a91f45577e57ac9c619b883587dbR1-R77) [[2]](diffhunk://#diff-b1811ebc1b7d5d66500aaad18043ed93e1ca4556e3cc8cf2834472a022533657R1-R84)

### Integration of `ConfirmationModal`:
* Updated `ActionButtons` to use the `ConfirmationModal` for discard and new upload actions, providing users with clear confirmation dialogs before proceeding with destructive or significant actions.
* Modified `ReportDetailPage` to pass necessary props (`reportTitle` and `reportId`) to `ActionButtons` for modal integration.

### Enhanced User Feedback:
* Added toast notifications to `ReportDetailPage` to inform users of the success or failure of the discard action.

### Localization Updates:
* Capitalized "Yes" and "No" in English (`common.json`), Spanish (`common.json`), and French (`common.json`) localization files for consistency. [[1]](diffhunk://#diff-aed186c5656c6fa8602dd5c744f72724db3d17faecc16b388a84fba32cbd693aL76-R79) [[2]](diffhunk://#diff-4d1dc53bbf2419fb54a3e9651d66f510b21669541e921afedcd7daee80376215L73-R76) [[3]](diffhunk://#diff-78cd351fc03721f4d0a0599283b8fa15ae44859e7765f8e11ba7481dd28344afL73-R76)

### Code Enhancements:
* Introduced `useToasts` to `ReportDetailPage` for toast management and updated the discard logic to handle errors gracefully. [[1]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364R10) [[2]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364R90-R114)

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
