### PR TITLE
[ADE-215] fix stale data in the app

### DIFF
--- a/backend/src/services/perplexity.service.ts
+++ b/backend/src/services/perplexity.service.ts
@@ -2,7 +2,7 @@ import { Injectable, Logger } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { AwsSecretsService } from './aws-secrets.service';
-import { LabValue } from 'src/document-processor/services/aws-bedrock.service';
+import { LabValue } from '../document-processor/services/aws-bedrock.service';
 
 export interface PerplexityMessage {
   role: 'system' | 'user' | 'assistant';

--- a/frontend/src/common/hooks/useChat.ts
+++ b/frontend/src/common/hooks/useChat.ts
@@ -1,21 +1,20 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { bedrockService } from '../services/ai/bedrock.service';
-
-export const CHAT_QUERY_KEY = 'chat';
+import { QueryKey } from 'common/utils/constants';
 
 export function useChat(sessionId?: string) {
   const queryClient = useQueryClient();
 
   // Query for getting chat session
   const { data: session } = useQuery({
-    queryKey: [CHAT_QUERY_KEY, sessionId],
+    queryKey: [QueryKey.Chat, sessionId],
     queryFn: () => (sessionId ? bedrockService.getChatSession(sessionId) : undefined),
     enabled: !!sessionId,
   });
 
   // Query for getting all sessions
   const { data: sessions } = useQuery({
-    queryKey: [CHAT_QUERY_KEY, 'sessions'],
+    queryKey: [QueryKey.Chat, 'sessions'],
     queryFn: () => bedrockService.getAllSessions(),
   });
 
@@ -23,7 +22,7 @@ export function useChat(sessionId?: string) {
   const createSession = useMutation({
     mutationFn: () => bedrockService.createChatSession(),
     onSuccess: (newSessionId) => {
-      queryClient.invalidateQueries({ queryKey: [CHAT_QUERY_KEY, 'sessions'] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Chat, 'sessions'] });
       return newSessionId;
     },
   });
@@ -35,8 +34,8 @@ export function useChat(sessionId?: string) {
       return bedrockService.sendMessage(sessionId, message);
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [CHAT_QUERY_KEY, sessionId] });
-      queryClient.invalidateQueries({ queryKey: [CHAT_QUERY_KEY, 'sessions'] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Chat, sessionId] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Chat, 'sessions'] });
     },
   });
 

--- a/frontend/src/common/hooks/useReports.ts
+++ b/frontend/src/common/hooks/useReports.ts
@@ -70,36 +70,35 @@ export const useMarkReportAsRead = () => {
 export const useToggleReportBookmark = () => {
   const queryClient = useQueryClient();
 
-  return async (reportId: string, isBookmarked: boolean) => {
-    return useMutation({
-      mutationFn: () => toggleReportBookmark(reportId, isBookmarked),
-      onSuccess: (updatedReport: MedicalReport) => {
-        // Update the reports cache
-        queryClient.setQueryData<MedicalReport[]>([QueryKey.Reports], (oldReports) => {
-          if (!oldReports) return undefined;
-          return oldReports.map((report) =>
-            report.id === updatedReport.id ? updatedReport : report,
-          );
-        });
-
-        // Update the latest reports cache
-        queryClient.setQueryData<MedicalReport[]>([QueryKey.LatestReports], (oldReports) => {
-          if (!oldReports) return undefined;
-          return oldReports.map((report) =>
-            report.id === updatedReport.id ? updatedReport : report,
-          );
-        });
-
-        // Update the bookmark status in the report detail page
-        queryClient.setQueryData<MedicalReport | undefined>(
-          [QueryKey.ReportDetail, reportId],
-          (oldReport) => {
-            if (!oldReport) return undefined;
-            if (oldReport.id !== updatedReport.id) return oldReport;
-            return { ...oldReport, bookmarked: updatedReport.bookmarked };
-          },
+  return useMutation({
+    mutationFn: ({ reportId, isBookmarked }: { reportId: string; isBookmarked: boolean }) =>
+      toggleReportBookmark(reportId, isBookmarked),
+    onSuccess: (updatedReport: MedicalReport) => {
+      // Update the reports cache
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.Reports], (oldReports) => {
+        if (!oldReports) return undefined;
+        return oldReports.map((report) =>
+          report.id === updatedReport.id ? updatedReport : report,
         );
-      },
-    });
-  };
+      });
+
+      // Update the latest reports cache
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.LatestReports], (oldReports) => {
+        if (!oldReports) return undefined;
+        return oldReports.map((report) =>
+          report.id === updatedReport.id ? updatedReport : report,
+        );
+      });
+
+      // Update the bookmark status in the report detail page
+      queryClient.setQueryData<MedicalReport | undefined>(
+        [QueryKey.ReportDetail, reportId],
+        (oldReport) => {
+          if (!oldReport) return undefined;
+          if (oldReport.id !== updatedReport.id) return oldReport;
+          return { ...oldReport, bookmarked: updatedReport.bookmarked };
+        },
+      );
+    },
+  });
 };

--- a/frontend/src/common/hooks/useReports.ts
+++ b/frontend/src/common/hooks/useReports.ts
@@ -1,10 +1,12 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchAllReports, fetchLatestReports, markReportAsRead } from '../api/reportService';
+import {
+  fetchAllReports,
+  fetchLatestReports,
+  markReportAsRead,
+  toggleReportBookmark,
+} from '../api/reportService';
 import { MedicalReport } from '../models/medicalReport';
-
-// Query keys
-const REPORTS_KEY = 'reports';
-const LATEST_REPORTS_KEY = 'latestReports';
+import { QueryKey } from 'common/utils/constants';
 
 /**
  * Hook to fetch the latest reports.
@@ -13,7 +15,7 @@ const LATEST_REPORTS_KEY = 'latestReports';
  */
 export const useGetLatestReports = (limit = 3) => {
   return useQuery({
-    queryKey: [LATEST_REPORTS_KEY, limit],
+    queryKey: [QueryKey.LatestReports, limit],
     queryFn: () => fetchLatestReports(limit),
     refetchOnMount: true,
     refetchOnWindowFocus: true,
@@ -27,7 +29,7 @@ export const useGetLatestReports = (limit = 3) => {
  */
 export const useGetAllReports = () => {
   return useQuery({
-    queryKey: [REPORTS_KEY],
+    queryKey: [QueryKey.Reports],
     queryFn: fetchAllReports,
   });
 };
@@ -43,7 +45,7 @@ export const useMarkReportAsRead = () => {
     mutationFn: (reportId: string) => markReportAsRead(reportId),
     onSuccess: (updatedReport: MedicalReport) => {
       // Update the reports cache
-      queryClient.setQueryData<MedicalReport[]>([REPORTS_KEY], (oldReports) => {
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.Reports], (oldReports) => {
         if (!oldReports) return undefined;
         return oldReports.map((report) =>
           report.id === updatedReport.id ? updatedReport : report,
@@ -51,7 +53,37 @@ export const useMarkReportAsRead = () => {
       });
 
       // Update the latest reports cache
-      queryClient.setQueryData<MedicalReport[]>([LATEST_REPORTS_KEY], (oldReports) => {
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.LatestReports], (oldReports) => {
+        if (!oldReports) return undefined;
+        return oldReports.map((report) =>
+          report.id === updatedReport.id ? updatedReport : report,
+        );
+      });
+    },
+  });
+};
+
+/**
+ * Hook to toggle the bookmark status of a report.
+ * @returns Mutation result for toggling the bookmark status
+ */
+export const useToggleReportBookmark = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (params: { reportId: string; isBookmarked: boolean }) =>
+      toggleReportBookmark(params.reportId, params.isBookmarked),
+    onSuccess: (updatedReport: MedicalReport) => {
+      // Update the reports cache
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.Reports], (oldReports) => {
+        if (!oldReports) return undefined;
+        return oldReports.map((report) =>
+          report.id === updatedReport.id ? updatedReport : report,
+        );
+      });
+
+      // Update the latest reports cache
+      queryClient.setQueryData<MedicalReport[]>([QueryKey.LatestReports], (oldReports) => {
         if (!oldReports) return undefined;
         return oldReports.map((report) =>
           report.id === updatedReport.id ? updatedReport : report,

--- a/frontend/src/common/utils/constants.ts
+++ b/frontend/src/common/utils/constants.ts
@@ -9,6 +9,10 @@ export enum QueryKey {
   UserProfile = 'UserProfile',
   Users = 'Users',
   UserTokens = 'UserTokens',
+  Chat = 'Chat',
+  Reports = 'Reports',
+  LatestReports = 'LatestReports',
+  ReportDetail = 'ReportDetail',
 }
 
 /**

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -12,11 +12,12 @@ import {
 import { useTranslation } from 'react-i18next';
 import { useHistory } from 'react-router-dom';
 import { useState } from 'react';
-import { useGetLatestReports, useMarkReportAsRead } from 'common/hooks/useReports';
+import {
+  useGetLatestReports,
+  useMarkReportAsRead,
+  useToggleReportBookmark,
+} from 'common/hooks/useReports';
 import { useCurrentUser } from 'common/hooks/useAuth';
-import { toggleReportBookmark } from 'common/api/reportService';
-import { useQueryClient } from '@tanstack/react-query';
-import { MedicalReport } from 'common/models/medicalReport';
 import Avatar from 'common/components/Icon/Avatar';
 import ReportItem from './components/ReportItem/ReportItem';
 import NoReportsMessage from './components/NoReportsMessage/NoReportsMessage';
@@ -30,7 +31,7 @@ import './HomePage.scss';
 const HomePage: React.FC = () => {
   const { t } = useTranslation('home');
   const history = useHistory();
-  const queryClient = useQueryClient();
+  const toggleBookmark = useToggleReportBookmark();
   const { data: reports, isLoading, isError } = useGetLatestReports(3);
   const { mutate: markAsRead } = useMarkReportAsRead();
   const currentUser = useCurrentUser();
@@ -45,31 +46,6 @@ const HomePage: React.FC = () => {
 
     // Navigate to the report detail page
     history.push(`/tabs/reports/${reportId}`);
-  };
-
-  const handleToggleBookmark = async (reportId: string, isCurrentlyBookmarked: boolean) => {
-    try {
-      // Toggle the bookmark status
-      const updatedReport = await toggleReportBookmark(reportId, !isCurrentlyBookmarked);
-
-      // Update the reports in the cache
-      queryClient.setQueryData<MedicalReport[]>(['reports'], (oldReports) => {
-        if (!oldReports) return [];
-        return oldReports.map((report) =>
-          report.id === updatedReport.id ? updatedReport : report,
-        );
-      });
-
-      // Update the latest reports cache with the correct query key including the limit
-      queryClient.setQueryData<MedicalReport[]>(['latestReports', 3], (oldReports) => {
-        if (!oldReports) return [];
-        return oldReports.map((report) =>
-          report.id === updatedReport.id ? updatedReport : report,
-        );
-      });
-    } catch (error) {
-      console.error('Failed to toggle bookmark:', error);
-    }
   };
 
   const handleUpload = () => {
@@ -121,7 +97,7 @@ const HomePage: React.FC = () => {
         key={report.id}
         report={report}
         onClick={() => handleReportClick(report.id)}
-        onToggleBookmark={() => handleToggleBookmark(report.id, report.bookmarked)}
+        onToggleBookmark={() => toggleBookmark(report.id, report.bookmarked)}
         showBookmarkButton={true}
       />
     ));

--- a/frontend/src/pages/Home/HomePage.tsx
+++ b/frontend/src/pages/Home/HomePage.tsx
@@ -97,7 +97,9 @@ const HomePage: React.FC = () => {
         key={report.id}
         report={report}
         onClick={() => handleReportClick(report.id)}
-        onToggleBookmark={() => toggleBookmark(report.id, report.bookmarked)}
+        onToggleBookmark={() =>
+          toggleBookmark.mutate({ reportId: report.id, isBookmarked: report.bookmarked })
+        }
         showBookmarkButton={true}
       />
     ));

--- a/frontend/src/pages/Processing/ProcessingPage.tsx
+++ b/frontend/src/pages/Processing/ProcessingPage.tsx
@@ -8,6 +8,8 @@ import './ProcessingPage.scss';
 import { getAuthConfig } from 'common/api/reportService';
 import ProcessingError from './components/ProcessingError';
 import ProcessingAnimation from './components/ProcessingAnimation';
+import { QueryKey } from 'common/utils/constants';
+import { useQueryClient } from '@tanstack/react-query';
 
 const API_URL = import.meta.env.VITE_BASE_URL_API || '';
 
@@ -20,6 +22,7 @@ const ProcessingPage: React.FC = () => {
   const firstName = currentUser?.name?.split(' ')[0];
   const axios = useAxios();
   const history = useHistory();
+  const queryClient = useQueryClient();
 
   // States to track processing
   const [isProcessing, setIsProcessing] = useState(true);
@@ -69,6 +72,9 @@ const ProcessingPage: React.FC = () => {
         clearStatusCheckInterval();
 
         console.log('Processing complete');
+
+        queryClient.invalidateQueries({ queryKey: [QueryKey.Reports] });
+        queryClient.invalidateQueries({ queryKey: [QueryKey.LatestReports] });
 
         history.push(`/tabs/reports/${reportId}`);
       } else if (data.status === 'failed') {

--- a/frontend/src/pages/Reports/ReportDetailPage.tsx
+++ b/frontend/src/pages/Reports/ReportDetailPage.tsx
@@ -2,7 +2,7 @@ import { IonPage, IonContent } from '@ionic/react';
 import { useState } from 'react';
 import { useHistory, useParams } from 'react-router-dom';
 import './ReportDetailPage.scss';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import { MedicalReport } from '../../common/models/medicalReport';
 import { useTranslation } from 'react-i18next';
@@ -39,6 +39,7 @@ const ReportDetailPage: React.FC = () => {
   const { t } = useTranslation();
   const { createToast } = useToasts();
   const [isUploadModalOpen, setIsUploadModalOpen] = useState(false);
+  const queryClient = useQueryClient();
 
   const handleUploadComplete = () => {
     setIsUploadModalOpen(false);
@@ -108,6 +109,10 @@ const ReportDetailPage: React.FC = () => {
         duration: 2000,
       });
 
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Reports] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.LatestReports] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ReportDetail, reportId] });
+
       // Navigate back
       history.push('/tabs/home');
     } catch (error) {
@@ -130,6 +135,11 @@ const ReportDetailPage: React.FC = () => {
       setIsProcessing(true);
       await axios.delete(`${API_URL}/api/reports/${reportId}`, await getAuthConfig());
       setIsProcessing(false);
+
+      queryClient.invalidateQueries({ queryKey: [QueryKey.Reports] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.LatestReports] });
+      queryClient.invalidateQueries({ queryKey: [QueryKey.ReportDetail, reportId] });
+
       setIsUploadModalOpen(true);
     } catch (error) {
       setIsProcessing(false);
@@ -169,7 +179,7 @@ const ReportDetailPage: React.FC = () => {
 
         <UploadModal
           isOpen={isUploadModalOpen}
-          onClose={() => setIsUploadModalOpen(false)}
+          onClose={handleUploadComplete}
           onUploadComplete={handleUploadComplete}
         />
       </IonContent>

--- a/frontend/src/pages/Reports/ReportDetailPage.tsx
+++ b/frontend/src/pages/Reports/ReportDetailPage.tsx
@@ -16,6 +16,7 @@ import InfoCard from './components/InfoCard';
 import ActionButtons from './components/ActionButtons';
 import AiAnalysisTab from './components/AiAnalysisTab';
 import UploadModal from 'common/components/Upload/UploadModal';
+import { QueryKey } from 'common/utils/constants';
 
 const API_URL = import.meta.env.VITE_BASE_URL_API || '';
 
@@ -46,7 +47,7 @@ const ReportDetailPage: React.FC = () => {
 
   // Fetch report data using react-query
   const { data, isLoading, error } = useQuery<MedicalReport>({
-    queryKey: ['report', reportId],
+    queryKey: [QueryKey.ReportDetail, reportId],
     queryFn: () => fetchReportById(reportId!),
     enabled: !!reportId,
   });

--- a/frontend/src/pages/Reports/ReportsListPage.tsx
+++ b/frontend/src/pages/Reports/ReportsListPage.tsx
@@ -31,6 +31,7 @@ import CategoryTag from './components/CategoryTag/CategoryTag';
 import ReportsFilterEmpty from './components/ReportsFilterEmpty/ReportsFilterEmpty';
 
 import './ReportsListPage.scss';
+import { QueryKey } from 'common/utils/constants';
 
 type FilterOption = 'all' | 'bookmarked';
 type SortDirection = 'desc' | 'asc';
@@ -65,7 +66,7 @@ const ReportsListPage: React.FC = () => {
     isError,
     refetch,
   } = useQuery({
-    queryKey: ['reports'],
+    queryKey: [QueryKey.Reports],
     queryFn: fetchAllReports,
     refetchOnMount: true,
   });

--- a/frontend/src/pages/Reports/ReportsListPage.tsx
+++ b/frontend/src/pages/Reports/ReportsListPage.tsx
@@ -226,7 +226,9 @@ const ReportsListPage: React.FC = () => {
         key={report.id}
         report={report}
         onClick={() => handleReportClick(report.id)}
-        onToggleBookmark={() => toggleBookmark(report.id, report.bookmarked)}
+        onToggleBookmark={() =>
+          toggleBookmark.mutate({ reportId: report.id, isBookmarked: report.bookmarked })
+        }
         showBookmarkButton
       />
     ));

--- a/frontend/src/pages/Reports/ReportsListPage.tsx
+++ b/frontend/src/pages/Reports/ReportsListPage.tsx
@@ -15,13 +15,12 @@ import {
 } from '@ionic/react';
 import { useTranslation } from 'react-i18next';
 import { useHistory, useLocation } from 'react-router-dom';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { fetchAllReports, toggleReportBookmark } from 'common/api/reportService';
-import { useMarkReportAsRead } from 'common/hooks/useReports';
+import { useQuery } from '@tanstack/react-query';
+import { fetchAllReports } from 'common/api/reportService';
+import { useMarkReportAsRead, useToggleReportBookmark } from 'common/hooks/useReports';
 import ReportItem from 'pages/Home/components/ReportItem/ReportItem';
 import NoReportsMessage from 'pages/Home/components/NoReportsMessage/NoReportsMessage';
 import { useState, useMemo, useEffect, useRef } from 'react';
-import { MedicalReport } from 'common/models/medicalReport';
 import sortSvg from 'assets/icons/sort.svg';
 import filterOutlineIcon from 'assets/icons/filter-outline.svg';
 import reportsIcon from 'assets/icons/reports.svg';
@@ -43,7 +42,7 @@ const ReportsListPage: React.FC = () => {
   const { t } = useTranslation(['report', 'common']);
   const history = useHistory();
   const location = useLocation();
-  const queryClient = useQueryClient();
+  const toggleBookmark = useToggleReportBookmark();
   const [filter, setFilter] = useState<FilterOption>('all');
   const [sortDirection, setSortDirection] = useState<SortDirection>('desc'); // Default sort by newest first
   const [showToast, setShowToast] = useState(false);
@@ -121,23 +120,6 @@ const ReportsListPage: React.FC = () => {
 
     // Navigate to the report detail page
     history.push(`/tabs/reports/${reportId}`);
-  };
-
-  const handleToggleBookmark = async (reportId: string, isCurrentlyBookmarked: boolean) => {
-    try {
-      // Toggle the bookmark status
-      const updatedReport = await toggleReportBookmark(reportId, !isCurrentlyBookmarked);
-
-      // Update the reports in the cache
-      queryClient.setQueryData<MedicalReport[]>(['reports'], (oldReports) => {
-        if (!oldReports) return [];
-        return oldReports.map((report) =>
-          report.id === updatedReport.id ? updatedReport : report,
-        );
-      });
-    } catch (error) {
-      console.error('Failed to toggle bookmark:', error);
-    }
   };
 
   const handleUpload = () => {
@@ -244,7 +226,7 @@ const ReportsListPage: React.FC = () => {
         key={report.id}
         report={report}
         onClick={() => handleReportClick(report.id)}
-        onToggleBookmark={() => handleToggleBookmark(report.id, report.bookmarked)}
+        onToggleBookmark={() => toggleBookmark(report.id, report.bookmarked)}
         showBookmarkButton
       />
     ));


### PR DESCRIPTION
### Change

This pull request introduces several changes to improve code maintainability and consistency, focusing on refactoring query keys into a centralized `QueryKey` enum, updating query-related logic, and enhancing the functionality of report-related features. The most significant changes include replacing hardcoded query keys with `QueryKey` constants, adding a new `useToggleReportBookmark` hook, and updating various components to use these improvements.

### Refactoring Query Keys:

* Replaced hardcoded query keys with constants from the new `QueryKey` enum in `frontend/src/common/utils/constants.ts` to ensure consistency and reduce duplication. This affects multiple files, including `useChat.ts`, `useReports.ts`, and several page components. [[1]](diffhunk://#diff-983cebfcbc90fde019a48f3f7104c0fd201eaeaf202fb4d68080915d28e1c640R12-R15) [[2]](diffhunk://#diff-7dac2ecf1b4c4a543c8efb9d81dc3c99e08aa93b79aa03e0cac5a9719f3b1dd7L3-R25) [[3]](diffhunk://#diff-1c926e5d779dfb0a4084c61e406de50f5a2e73ea370f4166ee87445ba9b437caL16-R18) [[4]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364L49-R51) [[5]](diffhunk://#diff-61672efebd8f929d23597a84683a5532d0af6d02bb9dba9ba6efa33f8cdf8554L68-R68)

### Report Bookmarking Enhancements:

* Added a `useToggleReportBookmark` hook in `useReports.ts` to encapsulate the logic for toggling the bookmark status of reports and updating relevant caches. This replaces the inline bookmark toggling logic previously scattered across components.
* Updated `HomePage.tsx`, `ReportsListPage.tsx`, and `ReportDetailPage.tsx` to use the new `useToggleReportBookmark` hook, simplifying the components and ensuring consistent cache updates. [[1]](diffhunk://#diff-73714ce3bd165da90439c6f7ffa399f4d8ee68dee380848c1df41a13a17e0a38L33-R34) [[2]](diffhunk://#diff-61672efebd8f929d23597a84683a5532d0af6d02bb9dba9ba6efa33f8cdf8554L45-R45) [[3]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364R112-R115)

### Query Cache Management:

* Improved cache invalidation for queries related to reports (`Reports`, `LatestReports`, and `ReportDetail`) in multiple components, ensuring that changes (e.g., toggling bookmarks, deleting reports) are properly reflected across the app. [[1]](diffhunk://#diff-0038dc053c9dc09335e2715dd1862ab07d58225054ada35c1e04ca339b28e34aR76-R78) [[2]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364R138-R142) [[3]](diffhunk://#diff-41d2e46246c1fcacef4f2cb888d10ce2e4087ed69ec7ab0bf5142ec5fe4c3364R112-R115)

### Minor Refactoring:

* Adjusted import paths for consistency, such as updating relative paths in `perplexity.service.ts`.
* Updated `HomePage.tsx` to use the `onClose` callback for the `UploadModal` component, improving its behavior.

These changes collectively improve the maintainability, readability, and functionality of the codebase.

### Does this PR introduce a breaking change?

{...}

### What needs to be documented once your changes are merged?

{...}

### Additional Comments

{...}
